### PR TITLE
Add jre8 versions

### DIFF
--- a/6-jre8/Dockerfile
+++ b/6-jre8/Dockerfile
@@ -1,0 +1,41 @@
+FROM java:8-jre
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
+
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+WORKDIR $CATALINA_HOME
+USER tomcat
+
+# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+RUN gpg --keyserver pgp.mit.edu --recv-keys \
+	05AB33110949707C93A279E3D3EFE6B686867BA6 \
+	07E48665A34DCAFAE522E5E6266191C37C037D42 \
+	47309207D818FFD8DCD3F83F1931D684307A10A5 \
+	541FBE7D8F78B25E055DDEE13C370389288584E7 \
+	61B832AC2F1C5A90F0F9B00A1C506407564C17A3 \
+	79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED \
+	80FF76D88A969FE46108558A80B953A041E49465 \
+	8B39757B1D8A994DF2433ED58B3A601F08C975E5 \
+	A27677289986DB50844682F8ACB77FC2E86E29AC \
+	A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 \
+	B3F49CD3B9BD2996DA90F817ED3873F5D3262722 \
+	DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 \
+	F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE \
+	F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+
+ENV TOMCAT_MAJOR 6
+ENV TOMCAT_VERSION 6.0.41
+ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+
+RUN curl -SL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
+	&& curl -SL "$TOMCAT_TGZ_URL.asc" -o tomcat.tar.gz.asc \
+	&& gpg --verify tomcat.tar.gz.asc \
+	&& tar -xvf tomcat.tar.gz --strip-components=1 \
+	&& rm bin/*.bat \
+	&& rm tomcat.tar.gz*
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/7-jre8/Dockerfile
+++ b/7-jre8/Dockerfile
@@ -1,0 +1,40 @@
+FROM java:8-jre
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
+
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+WORKDIR $CATALINA_HOME
+USER tomcat
+
+# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+RUN gpg --keyserver pgp.mit.edu --recv-keys \
+	05AB33110949707C93A279E3D3EFE6B686867BA6 \
+	07E48665A34DCAFAE522E5E6266191C37C037D42 \
+	47309207D818FFD8DCD3F83F1931D684307A10A5 \
+	541FBE7D8F78B25E055DDEE13C370389288584E7 \
+	61B832AC2F1C5A90F0F9B00A1C506407564C17A3 \
+	713DA88BE50911535FE716F5208B0AB1D63011C7 \
+	79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED \
+	9BA44C2621385CB966EBA586F72C284D731FABEE \
+	A27677289986DB50844682F8ACB77FC2E86E29AC \
+	A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 \
+	DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 \
+	F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE \
+	F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+
+ENV TOMCAT_MAJOR 7
+ENV TOMCAT_VERSION 7.0.57
+ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+
+RUN curl -SL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
+	&& curl -SL "$TOMCAT_TGZ_URL.asc" -o tomcat.tar.gz.asc \
+	&& gpg --verify tomcat.tar.gz.asc \
+	&& tar -xvf tomcat.tar.gz --strip-components=1 \
+	&& rm bin/*.bat \
+	&& rm tomcat.tar.gz*
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/8-jre8/Dockerfile
+++ b/8-jre8/Dockerfile
@@ -1,0 +1,39 @@
+FROM java:8-jre
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
+
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+WORKDIR $CATALINA_HOME
+USER tomcat
+
+# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+RUN gpg --keyserver pgp.mit.edu --recv-keys \
+	05AB33110949707C93A279E3D3EFE6B686867BA6 \
+	07E48665A34DCAFAE522E5E6266191C37C037D42 \
+	47309207D818FFD8DCD3F83F1931D684307A10A5 \
+	541FBE7D8F78B25E055DDEE13C370389288584E7 \
+	61B832AC2F1C5A90F0F9B00A1C506407564C17A3 \
+	79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED \
+	9BA44C2621385CB966EBA586F72C284D731FABEE \
+	A27677289986DB50844682F8ACB77FC2E86E29AC \
+	A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 \
+	DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 \
+	F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE \
+	F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+
+ENV TOMCAT_MAJOR 8
+ENV TOMCAT_VERSION 8.0.15
+ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+
+RUN curl -SL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
+	&& curl -SL "$TOMCAT_TGZ_URL.asc" -o tomcat.tar.gz.asc \
+	&& gpg --verify tomcat.tar.gz.asc \
+	&& tar -xvf tomcat.tar.gz --strip-components=1 \
+	&& rm bin/*.bat \
+	&& rm tomcat.tar.gz*
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Fixes #4

Much changes.

``` diff
$ diff -Nru 8-jre7/Dockerfile 8-jre8/Dockerfile
--- 8-jre7/Dockerfile   2014-11-20 13:31:53.587697874 -0800
+++ 8-jre8/Dockerfile   2014-11-20 13:31:54.319665844 -0800
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre

 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
```

It should have no compatibility problems according to the [apache tomcat site](https://tomcat.apache.org/whichversion.html).

> Each version of Tomcat is supported for any stable Java release that meets the requirements of the final column in the table above.
