### PR TITLE
Get rid of tomcat user for ease of use

### DIFF
--- a/6-jre7/Dockerfile
+++ b/6-jre7/Dockerfile
@@ -1,13 +1,9 @@
 FROM java:7-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
-
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
-USER tomcat
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN gpg --keyserver pgp.mit.edu --recv-keys \

--- a/6-jre8/Dockerfile
+++ b/6-jre8/Dockerfile
@@ -1,13 +1,9 @@
 FROM java:8-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
-
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
-USER tomcat
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN gpg --keyserver pgp.mit.edu --recv-keys \

--- a/7-jre7/Dockerfile
+++ b/7-jre7/Dockerfile
@@ -1,13 +1,9 @@
 FROM java:7-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
-
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
-USER tomcat
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN gpg --keyserver pgp.mit.edu --recv-keys \

--- a/7-jre8/Dockerfile
+++ b/7-jre8/Dockerfile
@@ -1,13 +1,9 @@
 FROM java:8-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
-
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
-USER tomcat
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN gpg --keyserver pgp.mit.edu --recv-keys \

--- a/8-jre7/Dockerfile
+++ b/8-jre7/Dockerfile
@@ -1,13 +1,9 @@
 FROM java:7-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
-
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
-USER tomcat
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN gpg --keyserver pgp.mit.edu --recv-keys \

--- a/8-jre8/Dockerfile
+++ b/8-jre8/Dockerfile
@@ -1,13 +1,9 @@
 FROM java:8-jre
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r tomcat && useradd -r --create-home -g tomcat tomcat
-
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-RUN mkdir -p "$CATALINA_HOME" && chown tomcat:tomcat "$CATALINA_HOME"
+RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
-USER tomcat
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN gpg --keyserver pgp.mit.edu --recv-keys \


### PR DESCRIPTION
I have tags `8-jre8` and `8-jre7`/`latest` building in an [automated build](https://registry.hub.docker.com/u/yosifkit/tomcat/) if someone can test them to ensure that their code works in it.

@bryantrobbins, or @jgangemi :pray:, think you could give it a quick test when you have a moment, especially in regards to our discussion about mounting into `$CATALINA_HOME/webapps` in #3.
