### PR TITLE
Issue #7: Add Tomcat Native Libraries

### DIFF
--- a/6-jre7/Dockerfile
+++ b/6-jre7/Dockerfile
@@ -34,5 +34,18 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq gcc make openssl libssl-dev libapr1 libapr1-dev openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
+	&& tar zxf /usr/local/tomcat/bin/tomcat-native.tar.gz -C /tmp \
+	&& cd /tmp/tomcat-native*-src/jni/native/ \
+	&& ./configure --with-apr=/usr/bin/apr-1-config --with-java-home=/usr/lib/jvm/java-7-openjdk-amd64/ --with-ssl=yes --libdir=/usr/lib/jni \
+	&& make \
+	&& make install \
+	&& apt-get purge -y openjdk-7-jdk="$JAVA_DEBIAN_VERSION" gcc make libssl-dev libapr1-dev \
+	&& apt-get -y autoremove \
+	&& rm -rf /tmp/tomcat-native* \
+	&& rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/6-jre8/Dockerfile
+++ b/6-jre8/Dockerfile
@@ -34,5 +34,18 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq gcc make openssl libssl-dev libapr1 libapr1-dev openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
+	&& tar zxf /usr/local/tomcat/bin/tomcat-native.tar.gz -C /tmp \
+	&& cd /tmp/tomcat-native*-src/jni/native/ \
+	&& ./configure --with-apr=/usr/bin/apr-1-config --with-java-home=/usr/lib/jvm/java-8-openjdk-amd64/ --with-ssl=yes --libdir=/usr/lib/jni \
+	&& make \
+	&& make install \
+	&& apt-get purge -y openjdk-8-jdk="$JAVA_DEBIAN_VERSION" gcc make libssl-dev libapr1-dev \
+	&& apt-get -y autoremove \
+	&& rm -rf /tmp/tomcat-native* \
+	&& rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/7-jre7/Dockerfile
+++ b/7-jre7/Dockerfile
@@ -33,5 +33,18 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq gcc make openssl libssl-dev libapr1 libapr1-dev openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
+	&& tar zxf /usr/local/tomcat/bin/tomcat-native.tar.gz -C /tmp \
+	&& cd /tmp/tomcat-native*-src/jni/native/ \
+	&& ./configure --with-apr=/usr/bin/apr-1-config --with-java-home=/usr/lib/jvm/java-7-openjdk-amd64/ --with-ssl=yes --libdir=/usr/lib/jni \
+	&& make \
+	&& make install \
+	&& apt-get purge -y openjdk-7-jdk="$JAVA_DEBIAN_VERSION" gcc make libssl-dev libapr1-dev \
+	&& apt-get -y autoremove \
+	&& rm -rf /tmp/tomcat-native* \
+	&& rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/7-jre8/Dockerfile
+++ b/7-jre8/Dockerfile
@@ -33,5 +33,18 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq gcc make openssl libssl-dev libapr1 libapr1-dev openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
+	&& tar zxf /usr/local/tomcat/bin/tomcat-native.tar.gz -C /tmp \
+	&& cd /tmp/tomcat-native*-src/jni/native/ \
+	&& ./configure --with-apr=/usr/bin/apr-1-config --with-java-home=/usr/lib/jvm/java-8-openjdk-amd64/ --with-ssl=yes --libdir=/usr/lib/jni \
+	&& make \
+	&& make install \
+	&& apt-get purge -y openjdk-8-jdk="$JAVA_DEBIAN_VERSION" gcc make libssl-dev libapr1-dev \
+	&& apt-get -y autoremove \
+	&& rm -rf /tmp/tomcat-native* \
+	&& rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/8-jre7/Dockerfile
+++ b/8-jre7/Dockerfile
@@ -32,5 +32,18 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq gcc make openssl libssl-dev libapr1 libapr1-dev openjdk-7-jdk="$JAVA_DEBIAN_VERSION" \
+	&& tar zxf /usr/local/tomcat/bin/tomcat-native.tar.gz -C /tmp \
+	&& cd /tmp/tomcat-native*-src/jni/native/ \
+	&& ./configure --with-apr=/usr/bin/apr-1-config --with-java-home=/usr/lib/jvm/java-7-openjdk-amd64/ --with-ssl=yes --libdir=/usr/lib/jni \
+	&& make \
+	&& make install \
+	&& apt-get purge -y openjdk-7-jdk="$JAVA_DEBIAN_VERSION" gcc make libssl-dev libapr1-dev \
+	&& apt-get -y autoremove \
+	&& rm -rf /tmp/tomcat-native* \
+	&& rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/8-jre8/Dockerfile
+++ b/8-jre8/Dockerfile
@@ -32,5 +32,18 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq gcc make openssl libssl-dev libapr1 libapr1-dev openjdk-8-jdk="$JAVA_DEBIAN_VERSION" \
+	&& tar zxf /usr/local/tomcat/bin/tomcat-native.tar.gz -C /tmp \
+	&& cd /tmp/tomcat-native*-src/jni/native/ \
+	&& ./configure --with-apr=/usr/bin/apr-1-config --with-java-home=/usr/lib/jvm/java-8-openjdk-amd64/ --with-ssl=yes --libdir=/usr/lib/jni \
+	&& make \
+	&& make install \
+	&& apt-get purge -y openjdk-8-jdk="$JAVA_DEBIAN_VERSION" gcc make libssl-dev libapr1-dev \
+	&& apt-get -y autoremove \
+	&& rm -rf /tmp/tomcat-native* \
+	&& rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Seems to work for every version of Tomcat and JRE in this repo -- seeing output like this when Tomcat starts:

```
Nov 17, 2015 5:46:38 PM org.apache.catalina.core.AprLifecycleListener lifecycleEvent
INFO: Loaded APR based Apache Tomcat Native library 1.1.33 using APR version 1.5.1.
Nov 17, 2015 5:46:38 PM org.apache.catalina.core.AprLifecycleListener lifecycleEvent
INFO: APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true].
Nov 17, 2015 5:46:38 PM org.apache.catalina.core.AprLifecycleListener initializeSSL
INFO: OpenSSL successfully initialized (OpenSSL 1.0.1k 8 Jan 2015)
```