### PR TITLE
Docker VOLUME set to '/usr/local/tomcat/webapps'

### DIFF
--- a/6-jre7/Dockerfile
+++ b/6-jre7/Dockerfile
@@ -34,5 +34,7 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+VOLUME /usr/local/tomcat/webapps
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/6-jre8/Dockerfile
+++ b/6-jre8/Dockerfile
@@ -34,5 +34,7 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+VOLUME /usr/local/tomcat/webapps
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/7-jre7/Dockerfile
+++ b/7-jre7/Dockerfile
@@ -33,5 +33,7 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+VOLUME /usr/local/tomcat/webapps
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/7-jre8/Dockerfile
+++ b/7-jre8/Dockerfile
@@ -33,5 +33,7 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+VOLUME /usr/local/tomcat/webapps
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/8-jre7/Dockerfile
+++ b/8-jre7/Dockerfile
@@ -32,5 +32,7 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+VOLUME /usr/local/tomcat/webapps
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/8-jre8/Dockerfile
+++ b/8-jre8/Dockerfile
@@ -32,5 +32,7 @@ RUN set -x \
 	&& rm bin/*.bat \
 	&& rm tomcat.tar.gz*
 
+VOLUME /usr/local/tomcat/webapps
+
 EXPOSE 8080
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Docker VOLUME set to '/usr/local/tomcat/webapps' in order to allow external mounting points to get integrated with tomcat containers.

This way, one can get its web applications stored outside the tomcat container using data-only containers (please see "Creating and mounting a data volume container"):

https://docs.docker.com/engine/userguide/dockervolumes/