### PR TITLE
Simplifying JMX monitoring using catalina-jmx-remote.jar

### DIFF
--- a/6-jre7/Dockerfile
+++ b/6-jre7/Dockerfile
@@ -25,6 +25,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
 ENV TOMCAT_MAJOR 6
 ENV TOMCAT_VERSION 6.0.44
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_JMX_REMOTE_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/extras/catalina-jmx-remote.jar
 
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -32,7 +33,11 @@ RUN set -x \
 	&& gpg --verify tomcat.tar.gz.asc \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
-	&& rm tomcat.tar.gz*
+	&& rm tomcat.tar.gz* \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL" -o catalina-jmx-remote.jar \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL.asc" -o catalina-jmx-remote.jar.asc \
+	&& gpg --verify catalina-jmx-remote.jar.asc \
+	&& mv catalina-jmx-remote.jar* ./lib
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/6-jre8/Dockerfile
+++ b/6-jre8/Dockerfile
@@ -25,6 +25,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
 ENV TOMCAT_MAJOR 6
 ENV TOMCAT_VERSION 6.0.44
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_JMX_REMOTE_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/extras/catalina-jmx-remote.jar
 
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -32,7 +33,11 @@ RUN set -x \
 	&& gpg --verify tomcat.tar.gz.asc \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
-	&& rm tomcat.tar.gz*
+	&& rm tomcat.tar.gz* \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL" -o catalina-jmx-remote.jar \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL.asc" -o catalina-jmx-remote.jar.asc \
+	&& gpg --verify catalina-jmx-remote.jar.asc \
+	&& mv catalina-jmx-remote.jar* ./lib
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/7-jre7/Dockerfile
+++ b/7-jre7/Dockerfile
@@ -24,6 +24,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
 ENV TOMCAT_MAJOR 7
 ENV TOMCAT_VERSION 7.0.67
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_JMX_REMOTE_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/extras/catalina-jmx-remote.jar
 
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -31,7 +32,11 @@ RUN set -x \
 	&& gpg --verify tomcat.tar.gz.asc \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
-	&& rm tomcat.tar.gz*
+	&& rm tomcat.tar.gz* \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL" -o catalina-jmx-remote.jar \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL.asc" -o catalina-jmx-remote.jar.asc \
+	&& gpg --verify catalina-jmx-remote.jar.asc \
+	&& mv catalina-jmx-remote.jar* ./lib
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/7-jre8/Dockerfile
+++ b/7-jre8/Dockerfile
@@ -24,6 +24,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
 ENV TOMCAT_MAJOR 7
 ENV TOMCAT_VERSION 7.0.67
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_JMX_REMOTE_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/extras/catalina-jmx-remote.jar
 
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -31,7 +32,11 @@ RUN set -x \
 	&& gpg --verify tomcat.tar.gz.asc \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
-	&& rm tomcat.tar.gz*
+	&& rm tomcat.tar.gz* \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL" -o catalina-jmx-remote.jar \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL.asc" -o catalina-jmx-remote.jar.asc \
+	&& gpg --verify catalina-jmx-remote.jar.asc \
+	&& mv catalina-jmx-remote.jar* ./lib
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/8-jre7/Dockerfile
+++ b/8-jre7/Dockerfile
@@ -23,6 +23,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.30
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_JMX_REMOTE_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/extras/catalina-jmx-remote.jar
 
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -30,7 +31,11 @@ RUN set -x \
 	&& gpg --verify tomcat.tar.gz.asc \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
-	&& rm tomcat.tar.gz*
+	&& rm tomcat.tar.gz* \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL" -o catalina-jmx-remote.jar \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL.asc" -o catalina-jmx-remote.jar.asc \
+	&& gpg --verify catalina-jmx-remote.jar.asc \
+	&& mv catalina-jmx-remote.jar* ./lib
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/8-jre8/Dockerfile
+++ b/8-jre8/Dockerfile
@@ -23,6 +23,7 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.30
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_JMX_REMOTE_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/extras/catalina-jmx-remote.jar
 
 RUN set -x \
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -30,7 +31,11 @@ RUN set -x \
 	&& gpg --verify tomcat.tar.gz.asc \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \
-	&& rm tomcat.tar.gz*
+	&& rm tomcat.tar.gz* \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL" -o catalina-jmx-remote.jar \
+	&& curl -fSL "$TOMCAT_JMX_REMOTE_URL.asc" -o catalina-jmx-remote.jar.asc \
+	&& gpg --verify catalina-jmx-remote.jar.asc \
+	&& mv catalina-jmx-remote.jar* ./lib
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Hi,

Monitoring Tomcat remotely can be done using JMX (https://tomcat.apache.org/tomcat-7.0-doc/monitoring.html). But the JSR 160 JMX-Adaptor opens a second data channel on a random port. That is a problem when you have a local firewall installed. To fix this, we need to configure a JmxRemoteLifecycleListener, as described in listeners documentation (https://tomcat.apache.org/tomcat-6.0-doc/config/listeners.html#JMX_Remote_Lifecycle_Listener_-_org.apache.catalina.mbeans.JmxRemoteLifecycleListener).

The configuration part can be achieved using a volume mapping to provide a custom server.xml, but the catalina-jmx-remote.jar is missing from the default distribution. This merge request adds the jar.