### PR TITLE
Add better openssl hackery to combat updated Tomcat Native

### DIFF
--- a/8.0/jre7/Dockerfile
+++ b/8.0/jre7/Dockerfile
@@ -5,8 +5,28 @@ ENV PATH $CATALINA_HOME/bin:$PATH
 RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
 
-# runtime dependency for Tomcat Native Libraries
-RUN apt-get update && apt-get install -y libapr1 && rm -rf /var/lib/apt/lists/*
+# runtime dependencies for Tomcat Native Libraries
+# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
+# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
+ENV OPENSSL_VERSION 1.0.2h-1
+RUN { \
+		echo 'deb http://httpredir.debian.org/debian unstable main'; \
+	} > /etc/apt/sources.list.d/unstable.list \
+	&& { \
+# add a negative "Pin-Priority" so that we never ever get packages from unstable unless we explicitly request them
+		echo 'Package: *'; \
+		echo 'Pin: release a=unstable'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+# except OpenSSL, which is the reason we're here
+		echo 'Package: openssl libssl*'; \
+		echo "Pin: version $OPENSSL_VERSION"; \
+		echo 'Pin-Priority: 990'; \
+	} > /etc/apt/preferences.d/unstable-openssl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libapr1 \
+		openssl="$OPENSSL_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN set -ex \
@@ -31,9 +51,6 @@ ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.35
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
-# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
-# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
-
 RUN set -x \
 	\
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -56,13 +73,6 @@ RUN set -x \
 	&& ( \
 		export CATALINA_HOME="$PWD" \
 		&& cd "$nativeBuildDir/native" \
-		&& [ "$(openssl version | cut -d' ' -f2)" = '1.0.1k' ] \
-# http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5048274.html (ie, HACK HACK HACK)
-		&& cp src/sslcontext.c src/sslcontext.c.orig \
-		&& awk ' \
-				/^    eckey = EC_KEY_new_by_curve_name/ { print "    EC_KEY *eckey = NULL;" } \
-				{ print } \
-			' src/sslcontext.c.orig > src/sslcontext.c \
 		&& ./configure \
 			--libdir=/usr/lib/jni \
 			--prefix="$CATALINA_HOME" \

--- a/8.0/jre8/Dockerfile
+++ b/8.0/jre8/Dockerfile
@@ -5,8 +5,28 @@ ENV PATH $CATALINA_HOME/bin:$PATH
 RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
 
-# runtime dependency for Tomcat Native Libraries
-RUN apt-get update && apt-get install -y libapr1 && rm -rf /var/lib/apt/lists/*
+# runtime dependencies for Tomcat Native Libraries
+# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
+# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
+ENV OPENSSL_VERSION 1.0.2h-1
+RUN { \
+		echo 'deb http://httpredir.debian.org/debian unstable main'; \
+	} > /etc/apt/sources.list.d/unstable.list \
+	&& { \
+# add a negative "Pin-Priority" so that we never ever get packages from unstable unless we explicitly request them
+		echo 'Package: *'; \
+		echo 'Pin: release a=unstable'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+# except OpenSSL, which is the reason we're here
+		echo 'Package: openssl libssl*'; \
+		echo "Pin: version $OPENSSL_VERSION"; \
+		echo 'Pin-Priority: 990'; \
+	} > /etc/apt/preferences.d/unstable-openssl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libapr1 \
+		openssl="$OPENSSL_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN set -ex \
@@ -31,9 +51,6 @@ ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.35
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
-# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
-# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
-
 RUN set -x \
 	\
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -56,13 +73,6 @@ RUN set -x \
 	&& ( \
 		export CATALINA_HOME="$PWD" \
 		&& cd "$nativeBuildDir/native" \
-		&& [ "$(openssl version | cut -d' ' -f2)" = '1.0.1k' ] \
-# http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5048274.html (ie, HACK HACK HACK)
-		&& cp src/sslcontext.c src/sslcontext.c.orig \
-		&& awk ' \
-				/^    eckey = EC_KEY_new_by_curve_name/ { print "    EC_KEY *eckey = NULL;" } \
-				{ print } \
-			' src/sslcontext.c.orig > src/sslcontext.c \
 		&& ./configure \
 			--libdir=/usr/lib/jni \
 			--prefix="$CATALINA_HOME" \

--- a/8.5/jre8/Dockerfile
+++ b/8.5/jre8/Dockerfile
@@ -5,8 +5,28 @@ ENV PATH $CATALINA_HOME/bin:$PATH
 RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
 
-# runtime dependency for Tomcat Native Libraries
-RUN apt-get update && apt-get install -y libapr1 && rm -rf /var/lib/apt/lists/*
+# runtime dependencies for Tomcat Native Libraries
+# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
+# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
+ENV OPENSSL_VERSION 1.0.2h-1
+RUN { \
+		echo 'deb http://httpredir.debian.org/debian unstable main'; \
+	} > /etc/apt/sources.list.d/unstable.list \
+	&& { \
+# add a negative "Pin-Priority" so that we never ever get packages from unstable unless we explicitly request them
+		echo 'Package: *'; \
+		echo 'Pin: release a=unstable'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+# except OpenSSL, which is the reason we're here
+		echo 'Package: openssl libssl*'; \
+		echo "Pin: version $OPENSSL_VERSION"; \
+		echo 'Pin-Priority: 990'; \
+	} > /etc/apt/preferences.d/unstable-openssl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libapr1 \
+		openssl="$OPENSSL_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN set -ex \
@@ -31,9 +51,6 @@ ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.5.2
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
-# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
-# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
-
 RUN set -x \
 	\
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -56,13 +73,6 @@ RUN set -x \
 	&& ( \
 		export CATALINA_HOME="$PWD" \
 		&& cd "$nativeBuildDir/native" \
-		&& [ "$(openssl version | cut -d' ' -f2)" = '1.0.1k' ] \
-# http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5048274.html (ie, HACK HACK HACK)
-		&& cp src/sslcontext.c src/sslcontext.c.orig \
-		&& awk ' \
-				/^    eckey = EC_KEY_new_by_curve_name/ { print "    EC_KEY *eckey = NULL;" } \
-				{ print } \
-			' src/sslcontext.c.orig > src/sslcontext.c \
 		&& ./configure \
 			--libdir=/usr/lib/jni \
 			--prefix="$CATALINA_HOME" \

--- a/9.0/jre8/Dockerfile
+++ b/9.0/jre8/Dockerfile
@@ -5,8 +5,28 @@ ENV PATH $CATALINA_HOME/bin:$PATH
 RUN mkdir -p "$CATALINA_HOME"
 WORKDIR $CATALINA_HOME
 
-# runtime dependency for Tomcat Native Libraries
-RUN apt-get update && apt-get install -y libapr1 && rm -rf /var/lib/apt/lists/*
+# runtime dependencies for Tomcat Native Libraries
+# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
+# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
+ENV OPENSSL_VERSION 1.0.2h-1
+RUN { \
+		echo 'deb http://httpredir.debian.org/debian unstable main'; \
+	} > /etc/apt/sources.list.d/unstable.list \
+	&& { \
+# add a negative "Pin-Priority" so that we never ever get packages from unstable unless we explicitly request them
+		echo 'Package: *'; \
+		echo 'Pin: release a=unstable'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+# except OpenSSL, which is the reason we're here
+		echo 'Package: openssl libssl*'; \
+		echo "Pin: version $OPENSSL_VERSION"; \
+		echo 'Pin-Priority: 990'; \
+	} > /etc/apt/preferences.d/unstable-openssl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libapr1 \
+		openssl="$OPENSSL_VERSION" \
+	&& rm -rf /var/lib/apt/lists/*
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
 RUN set -ex \
@@ -31,9 +51,6 @@ ENV TOMCAT_MAJOR 9
 ENV TOMCAT_VERSION 9.0.0.M6
 ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
-# Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
-# see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
-
 RUN set -x \
 	\
 	&& curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz \
@@ -56,13 +73,6 @@ RUN set -x \
 	&& ( \
 		export CATALINA_HOME="$PWD" \
 		&& cd "$nativeBuildDir/native" \
-		&& [ "$(openssl version | cut -d' ' -f2)" = '1.0.1k' ] \
-# http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5048274.html (ie, HACK HACK HACK)
-		&& cp src/sslcontext.c src/sslcontext.c.orig \
-		&& awk ' \
-				/^    eckey = EC_KEY_new_by_curve_name/ { print "    EC_KEY *eckey = NULL;" } \
-				{ print } \
-			' src/sslcontext.c.orig > src/sslcontext.c \
 		&& ./configure \
 			--libdir=/usr/lib/jni \
 			--prefix="$CATALINA_HOME" \


### PR DESCRIPTION
```
checking OpenSSL library version >= 1.0.2...

Found   OPENSSL_VERSION_NUMBER 0x100010bf (OpenSSL 1.0.1k 8 Jan 2015)
Require OPENSSL_VERSION_NUMBER 0x1000200f or greater (1.0.2)

configure: error: Your version of OpenSSL is not compatible with this version of tcnative
```

https://github.com/docker-library/official-images/pull/1740#issuecomment-219565444