### PR TITLE
Modified download url to use archive.apache.org so that images won't suddenly die

### DIFF
--- a/6/jre7/Dockerfile
+++ b/6/jre7/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 6
 ENV TOMCAT_VERSION 6.0.45
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/6/jre8/Dockerfile
+++ b/6/jre8/Dockerfile
@@ -31,7 +31,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 6
 ENV TOMCAT_VERSION 6.0.45
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/7/jre7-alpine/Dockerfile
+++ b/7/jre7-alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 7
 ENV TOMCAT_VERSION 7.0.72
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/7/jre7/Dockerfile
+++ b/7/jre7/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 7
 ENV TOMCAT_VERSION 7.0.72
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/7/jre8-alpine/Dockerfile
+++ b/7/jre8-alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 7
 ENV TOMCAT_VERSION 7.0.72
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/7/jre8/Dockerfile
+++ b/7/jre8/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 7
 ENV TOMCAT_VERSION 7.0.72
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/8.0/jre7-alpine/Dockerfile
+++ b/8.0/jre7-alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.37
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/8.0/jre7/Dockerfile
+++ b/8.0/jre7/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.37
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/8.0/jre8-alpine/Dockerfile
+++ b/8.0/jre8-alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.37
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/8.0/jre8/Dockerfile
+++ b/8.0/jre8/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.37
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/8.5/jre8-alpine/Dockerfile
+++ b/8.5/jre8-alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.5.5
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/8.5/jre8/Dockerfile
+++ b/8.5/jre8/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.5.5
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/9.0/jre8-alpine/Dockerfile
+++ b/9.0/jre8-alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 9
 ENV TOMCAT_VERSION 9.0.0.M10
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/9.0/jre8/Dockerfile
+++ b/9.0/jre8/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR 9
 ENV TOMCAT_VERSION 9.0.0.M10
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -33,7 +33,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR placeholder
 ENV TOMCAT_VERSION placeholder
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -54,7 +54,7 @@ RUN set -ex \
 
 ENV TOMCAT_MAJOR placeholder
 ENV TOMCAT_VERSION placeholder
-ENV TOMCAT_TGZ_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
 
 RUN set -x \
 	\


### PR DESCRIPTION
As I'm sure you are aware, when a version of tomcat is updated on the tomcat website, they remove the download for the previous version.
This pull request uses the archive.apache.org download link for every version of tomcat so that builds should always be successful, regardless of when they are run.