### PR TITLE
Add smoke test for Tomcat 6

### DIFF
--- a/6/jre7/Dockerfile
+++ b/6/jre7/Dockerfile
@@ -86,8 +86,23 @@ RUN set -x \
 	&& rm -rf "$nativeBuildDir" \
 	&& rm bin/tomcat-native.tar.gz
 
-# TODO find a simple hacky way to verify Tomcat Native is working properly
-# (the way we use in 7+ doesn't work here because we have no "configtest")
+# verify mod_cluster is working properly
+RUN set -e \
+	&& catalina.sh start \
+	&& while ! grep -q 'Server startup in' logs/catalina.out; do \
+		echo -n .; sleep .2; \
+	done; echo \
+	&& catalina.sh stop \
+	&& while pgrep java >/dev/null; do \
+		echo -n .; sleep .2; \
+	done; echo \
+	&& nativeLines="$(grep 'Apache Tomcat Native' logs/catalina.out)" \
+	&& nativeLines="$(echo "$nativeLines" | sort -u)" \
+	&& if ! echo "$nativeLines" | grep 'INFO: Loaded APR based Apache Tomcat Native library' >&2; then \
+		echo >&2 "$nativeLines"; \
+		exit 1; \
+	fi \
+	&& rm -rf conf/Catalina work/Catalina logs/*
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/6/jre8/Dockerfile
+++ b/6/jre8/Dockerfile
@@ -86,8 +86,23 @@ RUN set -x \
 	&& rm -rf "$nativeBuildDir" \
 	&& rm bin/tomcat-native.tar.gz
 
-# TODO find a simple hacky way to verify Tomcat Native is working properly
-# (the way we use in 7+ doesn't work here because we have no "configtest")
+# verify mod_cluster is working properly
+RUN set -e \
+	&& catalina.sh start \
+	&& while ! grep -q 'Server startup in' logs/catalina.out; do \
+		echo -n .; sleep .2; \
+	done; echo \
+	&& catalina.sh stop \
+	&& while pgrep java >/dev/null; do \
+		echo -n .; sleep .2; \
+	done; echo \
+	&& nativeLines="$(grep 'Apache Tomcat Native' logs/catalina.out)" \
+	&& nativeLines="$(echo "$nativeLines" | sort -u)" \
+	&& if ! echo "$nativeLines" | grep 'INFO: Loaded APR based Apache Tomcat Native library' >&2; then \
+		echo >&2 "$nativeLines"; \
+		exit 1; \
+	fi \
+	&& rm -rf conf/Catalina work/Catalina logs/*
 
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -72,16 +72,3 @@ RUN set -x \
 	&& apk del .fetch-deps .native-build-deps \
 	&& rm -rf "$nativeBuildDir" \
 	&& rm bin/tomcat-native.tar.gz
-
-# verify Tomcat Native is working properly
-RUN set -e \
-	&& nativeLines="$(catalina.sh configtest 2>&1)" \
-	&& nativeLines="$(echo "$nativeLines" | grep 'Apache Tomcat Native')" \
-	&& nativeLines="$(echo "$nativeLines" | sort -u)" \
-	&& if ! echo "$nativeLines" | grep 'INFO: Loaded APR based Apache Tomcat Native library' >&2; then \
-		echo >&2 "$nativeLines"; \
-		exit 1; \
-	fi
-
-EXPOSE 8080
-CMD ["catalina.sh", "run"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -85,16 +85,3 @@ RUN set -x \
 	&& apt-get purge -y --auto-remove $nativeBuildDeps \
 	&& rm -rf "$nativeBuildDir" \
 	&& rm bin/tomcat-native.tar.gz
-
-# verify Tomcat Native is working properly
-RUN set -e \
-	&& nativeLines="$(catalina.sh configtest 2>&1)" \
-	&& nativeLines="$(echo "$nativeLines" | grep 'Apache Tomcat Native')" \
-	&& nativeLines="$(echo "$nativeLines" | sort -u)" \
-	&& if ! echo "$nativeLines" | grep 'INFO: Loaded APR based Apache Tomcat Native library' >&2; then \
-		echo >&2 "$nativeLines"; \
-		exit 1; \
-	fi
-
-EXPOSE 8080
-CMD ["catalina.sh", "run"]


### PR DESCRIPTION
Proposal for the missing smoke test on Tomcat 6 variants.

1. start Catalina
2. wait for it to be started (grep log file)
3. stop it
4. wait for a graceful shutdown (otherwise it leaves data inside `/tmp/hsperfdata_root/`)
5. grep `nativeLines` as usual
6. cleanup

Output:
```
 ---> Running in 174b10742d68
.......
......
INFO: Loaded APR based Apache Tomcat Native library 1.2.10 using APR version 1.5.1.
```