### PR TITLE
Update "8" and "latest" tags to point to "8.5" (now that it's stable)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -9,7 +9,7 @@ declare -A latestVariant=(
 	[9.0]='jre8'
 )
 declare -A aliases=(
-	[8.0]='8 latest'
+	[8.5]='8 latest'
 	[9.0]='9'
 )
 


### PR DESCRIPTION
See https://tomcat.apache.org/oldnews-2016.html, specifically the transition from "Tomcat 8.5.2 (beta) Released" to "Tomcat 8.5.3 Released", and the download page for Tomcat 8 (https://tomcat.apache.org/download-80.cgi) which offers 8.5.13 before 8.0.43. :metal:

See also https://github.com/docker-library/official-images/pull/2841#issuecomment-293017354. :+1: