### PR TITLE
Allow downloads to fallback to archive.apache.org if (and only if) the redirector fails (which will usually be due to it being an older release, and thus not mirrored anymore, or a brand new release, and thus not mirrored yet)

### DIFF
--- a/7/jre7-alpine/Dockerfile
+++ b/7/jre7-alpine/Dockerfile
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/7/jre7/Dockerfile
+++ b/7/jre7/Dockerfile
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/7/jre8-alpine/Dockerfile
+++ b/7/jre8-alpine/Dockerfile
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/7/jre8/Dockerfile
+++ b/7/jre8/Dockerfile
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/8.0/jre7-alpine/Dockerfile
+++ b/8.0/jre7-alpine/Dockerfile
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/8.0/jre7/Dockerfile
+++ b/8.0/jre7/Dockerfile
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/8.0/jre8-alpine/Dockerfile
+++ b/8.0/jre8-alpine/Dockerfile
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/8.0/jre8/Dockerfile
+++ b/8.0/jre8/Dockerfile
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/8.5/jre8-alpine/Dockerfile
+++ b/8.5/jre8-alpine/Dockerfile
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/8.5/jre8/Dockerfile
+++ b/8.5/jre8/Dockerfile
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/9.0/jre8-alpine/Dockerfile
+++ b/9.0/jre8-alpine/Dockerfile
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/9.0/jre8/Dockerfile
+++ b/9.0/jre8/Dockerfile
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -27,14 +27,24 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .fetch-deps \
 		ca-certificates \
 		tar \
 		openssl \
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -55,10 +55,20 @@ ENV TOMCAT_TGZ_URL https://www.apache.org/dyn/closer.cgi?action=download&filenam
 # not all the mirrors actually carry the .asc files :'(
 ENV TOMCAT_ASC_URL https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
 
+# if the version is outdated, we have to pull from the archive :/
+ENV TOMCAT_TGZ_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV TOMCAT_ASC_FALLBACK_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc
+
 RUN set -x \
 	\
-	&& wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
-	&& wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+	&& { \
+		wget -O tomcat.tar.gz "$TOMCAT_TGZ_URL" \
+		|| wget -O tomcat.tar.gz "$TOMCAT_TGZ_FALLBACK_URL" \
+	; } \
+	&& { \
+		wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_URL" \
+		|| wget -O tomcat.tar.gz.asc "$TOMCAT_ASC_FALLBACK_URL" \
+	; } \
 	&& gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz \
 	&& tar -xvf tomcat.tar.gz --strip-components=1 \
 	&& rm bin/*.bat \


### PR DESCRIPTION
See also https://github.com/docker-library/httpd/commit/109e6332af1ac4176aefd7aad1c28e42f9e10644 (from https://github.com/docker-library/httpd/pull/57).