### PR TITLE
Switch "latest" variants from OpenJDK to Temurin

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -2,9 +2,11 @@
   "10.0": {
     "sha512": "fe46db8794f066882b30e7a94bd8d3dbcf29e8e8ffaf67c1355846755745a7c9eafd124819283f218bcf410921a485b44b57b56fd6251fb99d67d95f3dd36826",
     "variants": [
-      "jdk17/corretto",
       "jdk17/temurin-focal",
       "jre17/temurin-focal",
+      "jdk17/corretto",
+      "jdk11/temurin-focal",
+      "jre11/temurin-focal",
       "jdk11/openjdk-bullseye",
       "jre11/openjdk-bullseye",
       "jdk11/openjdk-buster",
@@ -14,8 +16,8 @@
       "jdk11/openjdk-slim-buster",
       "jre11/openjdk-slim-buster",
       "jdk11/corretto",
-      "jdk11/temurin-focal",
-      "jre11/temurin-focal",
+      "jdk8/temurin-focal",
+      "jre8/temurin-focal",
       "jdk8/openjdk-bullseye",
       "jre8/openjdk-bullseye",
       "jdk8/openjdk-buster",
@@ -24,18 +26,18 @@
       "jre8/openjdk-slim-bullseye",
       "jdk8/openjdk-slim-buster",
       "jre8/openjdk-slim-buster",
-      "jdk8/corretto",
-      "jdk8/temurin-focal",
-      "jre8/temurin-focal"
+      "jdk8/corretto"
     ],
     "version": "10.0.22"
   },
   "10.1": {
     "sha512": "ad25f3393324ce42619d6aeeb685186322776b5ba4583453c5e16957fa71cd64fa9f30e379985d57a701be43e9475991312893ee87979e69dd2b51de06510060",
     "variants": [
-      "jdk17/corretto",
       "jdk17/temurin-focal",
       "jre17/temurin-focal",
+      "jdk17/corretto",
+      "jdk11/temurin-focal",
+      "jre11/temurin-focal",
       "jdk11/openjdk-bullseye",
       "jre11/openjdk-bullseye",
       "jdk11/openjdk-buster",
@@ -44,18 +46,18 @@
       "jre11/openjdk-slim-bullseye",
       "jdk11/openjdk-slim-buster",
       "jre11/openjdk-slim-buster",
-      "jdk11/corretto",
-      "jdk11/temurin-focal",
-      "jre11/temurin-focal"
+      "jdk11/corretto"
     ],
     "version": "10.1.0-M16"
   },
   "8.5": {
     "sha512": "729387275cce4a0900289722f6c70ebcf7aee924af671b110b8ea8577fd6d045d47f17d526c8db5fd41c8590102e7f5100e95e89f7fd511b941565812ecbed35",
     "variants": [
-      "jdk17/corretto",
       "jdk17/temurin-focal",
       "jre17/temurin-focal",
+      "jdk17/corretto",
+      "jdk11/temurin-focal",
+      "jre11/temurin-focal",
       "jdk11/openjdk-bullseye",
       "jre11/openjdk-bullseye",
       "jdk11/openjdk-buster",
@@ -65,8 +67,8 @@
       "jdk11/openjdk-slim-buster",
       "jre11/openjdk-slim-buster",
       "jdk11/corretto",
-      "jdk11/temurin-focal",
-      "jre11/temurin-focal",
+      "jdk8/temurin-focal",
+      "jre8/temurin-focal",
       "jdk8/openjdk-bullseye",
       "jre8/openjdk-bullseye",
       "jdk8/openjdk-buster",
@@ -75,18 +77,18 @@
       "jre8/openjdk-slim-bullseye",
       "jdk8/openjdk-slim-buster",
       "jre8/openjdk-slim-buster",
-      "jdk8/corretto",
-      "jdk8/temurin-focal",
-      "jre8/temurin-focal"
+      "jdk8/corretto"
     ],
     "version": "8.5.81"
   },
   "9.0": {
     "sha512": "38392b651fabe706fb0524c52849601299494178010bb8077af383232c20bbbda1aec4ab8898adb2cc37c07583ff0e9d3c7038ce55a22bc68c3641641b47fd1a",
     "variants": [
-      "jdk17/corretto",
       "jdk17/temurin-focal",
       "jre17/temurin-focal",
+      "jdk17/corretto",
+      "jdk11/temurin-focal",
+      "jre11/temurin-focal",
       "jdk11/openjdk-bullseye",
       "jre11/openjdk-bullseye",
       "jdk11/openjdk-buster",
@@ -96,8 +98,8 @@
       "jdk11/openjdk-slim-buster",
       "jre11/openjdk-slim-buster",
       "jdk11/corretto",
-      "jdk11/temurin-focal",
-      "jre11/temurin-focal",
+      "jdk8/temurin-focal",
+      "jre8/temurin-focal",
       "jdk8/openjdk-bullseye",
       "jre8/openjdk-bullseye",
       "jdk8/openjdk-buster",
@@ -106,9 +108,7 @@
       "jre8/openjdk-slim-bullseye",
       "jdk8/openjdk-slim-buster",
       "jre8/openjdk-slim-buster",
-      "jdk8/corretto",
-      "jdk8/temurin-focal",
-      "jre8/temurin-focal"
+      "jdk8/corretto"
     ],
     "version": "9.0.64"
   }

--- a/versions.sh
+++ b/versions.sh
@@ -27,8 +27,12 @@ _bashbrew_list() {
 
 allVariants='[]'
 for javaVersion in 17 11 8; do
-	# OpenJDK, followed by all other variants alphabetically
-	for vendorVariant in openjdk{,-slim}-{bullseye,buster} corretto temurin-focal; do
+	# Eclipse Temurin, followed by OpenJDK, and then all other variants alphabetically
+	for vendorVariant in \
+		temurin-focal \
+		openjdk{,-slim}-{bullseye,buster} \
+		corretto \
+	; do
 		for javaVariant in {jdk,jre}"$javaVersion"; do
 			export variant="$javaVariant/$vendorVariant"
 			if image="$(jq -nr '


### PR DESCRIPTION
This is in preparation of the OpenJDK image deprecation -- see https://snyk.io/jvm-ecosystem-report-2021/ for a reasonable justification for Temurin being the new default (the OpenJDK image is being deprecated largely because Temurin already *is* roughly vanilla OpenJDK builds, but with proper community support).

See also https://github.com/docker-library/docs/pull/2162, https://github.com/docker-library/openjdk/issues/505

While making this change, I noticed/realized we should add the `jammy` variants of Temurin, but didn't want to conflate that and this.