### PR TITLE
Switch from "--with-ssl=yes" to "--with-ssl"

### DIFF
--- a/10.0/jdk11/corretto/Dockerfile
+++ b/10.0/jdk11/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk11/openjdk-bullseye/Dockerfile
+++ b/10.0/jdk11/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk11/openjdk-buster/Dockerfile
+++ b/10.0/jdk11/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk11/openjdk-slim-bullseye/Dockerfile
+++ b/10.0/jdk11/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk11/openjdk-slim-buster/Dockerfile
+++ b/10.0/jdk11/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk11/temurin-focal/Dockerfile
+++ b/10.0/jdk11/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk11/temurin-jammy/Dockerfile
+++ b/10.0/jdk11/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk17/corretto/Dockerfile
+++ b/10.0/jdk17/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk17/temurin-focal/Dockerfile
+++ b/10.0/jdk17/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk17/temurin-jammy/Dockerfile
+++ b/10.0/jdk17/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/corretto/Dockerfile
+++ b/10.0/jdk8/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/openjdk-bullseye/Dockerfile
+++ b/10.0/jdk8/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/openjdk-buster/Dockerfile
+++ b/10.0/jdk8/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/openjdk-slim-bullseye/Dockerfile
+++ b/10.0/jdk8/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/openjdk-slim-buster/Dockerfile
+++ b/10.0/jdk8/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/temurin-focal/Dockerfile
+++ b/10.0/jdk8/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.0/jdk8/temurin-jammy/Dockerfile
+++ b/10.0/jdk8/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/corretto/Dockerfile
+++ b/10.1/jdk11/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/openjdk-bullseye/Dockerfile
+++ b/10.1/jdk11/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/openjdk-buster/Dockerfile
+++ b/10.1/jdk11/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/openjdk-slim-bullseye/Dockerfile
+++ b/10.1/jdk11/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/openjdk-slim-buster/Dockerfile
+++ b/10.1/jdk11/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/temurin-focal/Dockerfile
+++ b/10.1/jdk11/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk11/temurin-jammy/Dockerfile
+++ b/10.1/jdk11/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk17/corretto/Dockerfile
+++ b/10.1/jdk17/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk17/temurin-focal/Dockerfile
+++ b/10.1/jdk17/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/10.1/jdk17/temurin-jammy/Dockerfile
+++ b/10.1/jdk17/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/corretto/Dockerfile
+++ b/8.5/jdk11/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/openjdk-bullseye/Dockerfile
+++ b/8.5/jdk11/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/openjdk-buster/Dockerfile
+++ b/8.5/jdk11/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/openjdk-slim-bullseye/Dockerfile
+++ b/8.5/jdk11/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/openjdk-slim-buster/Dockerfile
+++ b/8.5/jdk11/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/temurin-focal/Dockerfile
+++ b/8.5/jdk11/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk11/temurin-jammy/Dockerfile
+++ b/8.5/jdk11/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk17/corretto/Dockerfile
+++ b/8.5/jdk17/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk17/temurin-focal/Dockerfile
+++ b/8.5/jdk17/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk17/temurin-jammy/Dockerfile
+++ b/8.5/jdk17/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/corretto/Dockerfile
+++ b/8.5/jdk8/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/openjdk-bullseye/Dockerfile
+++ b/8.5/jdk8/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/openjdk-buster/Dockerfile
+++ b/8.5/jdk8/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/openjdk-slim-bullseye/Dockerfile
+++ b/8.5/jdk8/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/openjdk-slim-buster/Dockerfile
+++ b/8.5/jdk8/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/temurin-focal/Dockerfile
+++ b/8.5/jdk8/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/8.5/jdk8/temurin-jammy/Dockerfile
+++ b/8.5/jdk8/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/corretto/Dockerfile
+++ b/9.0/jdk11/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/openjdk-bullseye/Dockerfile
+++ b/9.0/jdk11/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/openjdk-buster/Dockerfile
+++ b/9.0/jdk11/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/openjdk-slim-bullseye/Dockerfile
+++ b/9.0/jdk11/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/openjdk-slim-buster/Dockerfile
+++ b/9.0/jdk11/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/temurin-focal/Dockerfile
+++ b/9.0/jdk11/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk11/temurin-jammy/Dockerfile
+++ b/9.0/jdk11/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk17/corretto/Dockerfile
+++ b/9.0/jdk17/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk17/temurin-focal/Dockerfile
+++ b/9.0/jdk17/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk17/temurin-jammy/Dockerfile
+++ b/9.0/jdk17/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/corretto/Dockerfile
+++ b/9.0/jdk8/corretto/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/openjdk-bullseye/Dockerfile
+++ b/9.0/jdk8/openjdk-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/openjdk-buster/Dockerfile
+++ b/9.0/jdk8/openjdk-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/openjdk-slim-bullseye/Dockerfile
+++ b/9.0/jdk8/openjdk-slim-bullseye/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/openjdk-slim-buster/Dockerfile
+++ b/9.0/jdk8/openjdk-slim-buster/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/temurin-focal/Dockerfile
+++ b/9.0/jdk8/temurin-focal/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/9.0/jdk8/temurin-jammy/Dockerfile
+++ b/9.0/jdk8/temurin-jammy/Dockerfile
@@ -98,7 +98,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -193,7 +193,7 @@ RUN set -eux; \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl=yes \
+			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \


### PR DESCRIPTION
This is an attempt to figure out the right solution for the failing @docker-library-bot updates to 10.1.0-M17 (which updates Tomcat Native from 1.2.34 to 2.0.1; https://github.com/apache/tomcat/commit/cb1b9683eb073ec99c11bc69e0c8dd12f5d155ee).  It appears that Tomcat Native between those revisions has made some backwards-incompatible changes to the way the `--with-ssl` flag is parsed (previously `yes|no|path`, now maybe just `path`?). :sweat_smile: