### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/10.1/jdk11/temurin-jammy/Dockerfile
+++ b/10.1/jdk11/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/10.1/jdk17/temurin-jammy/Dockerfile
+++ b/10.1/jdk17/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/11.0/jdk17/temurin-jammy/Dockerfile
+++ b/11.0/jdk17/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk11/corretto-al2/Dockerfile
+++ b/8.5/jdk11/corretto-al2/Dockerfile
@@ -82,7 +82,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk11/temurin-focal/Dockerfile
+++ b/8.5/jdk11/temurin-focal/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk11/temurin-jammy/Dockerfile
+++ b/8.5/jdk11/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk17/corretto-al2/Dockerfile
+++ b/8.5/jdk17/corretto-al2/Dockerfile
@@ -82,7 +82,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk17/temurin-focal/Dockerfile
+++ b/8.5/jdk17/temurin-focal/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk17/temurin-jammy/Dockerfile
+++ b/8.5/jdk17/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk8/corretto-al2/Dockerfile
+++ b/8.5/jdk8/corretto-al2/Dockerfile
@@ -82,7 +82,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk8/temurin-focal/Dockerfile
+++ b/8.5/jdk8/temurin-focal/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/8.5/jdk8/temurin-jammy/Dockerfile
+++ b/8.5/jdk8/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk11/corretto-al2/Dockerfile
+++ b/9.0/jdk11/corretto-al2/Dockerfile
@@ -82,7 +82,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk11/temurin-focal/Dockerfile
+++ b/9.0/jdk11/temurin-focal/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk11/temurin-jammy/Dockerfile
+++ b/9.0/jdk11/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk17/corretto-al2/Dockerfile
+++ b/9.0/jdk17/corretto-al2/Dockerfile
@@ -82,7 +82,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk17/temurin-focal/Dockerfile
+++ b/9.0/jdk17/temurin-focal/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk17/temurin-jammy/Dockerfile
+++ b/9.0/jdk17/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk8/corretto-al2/Dockerfile
+++ b/9.0/jdk8/corretto-al2/Dockerfile
@@ -82,7 +82,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk8/temurin-focal/Dockerfile
+++ b/9.0/jdk8/temurin-focal/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/9.0/jdk8/temurin-jammy/Dockerfile
+++ b/9.0/jdk8/temurin-jammy/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 	\
@@ -70,7 +69,7 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -91,7 +91,6 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		curl \
-		dirmngr \
 		gnupg \
 	; \
 {{ ) else ( -}}
@@ -153,7 +152,9 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	command -v gpgconf && gpgconf --kill all || :; \
+{{ if vendor_variant | contains("al2") then "" else ( -}}
+	gpgconf --kill all; \
+{{ ) end -}}
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).

(I'm not positive whether my `gpgconf --kill all` change here will work in _all_ the base images this repository supports, so I might have to back that one back out :sob:)