### PR TITLE
Skip upstream openjdk entrypoint

### DIFF
--- a/10.1/jdk11/temurin-jammy/Dockerfile
+++ b/10.1/jdk11/temurin-jammy/Dockerfile
@@ -145,4 +145,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/10.1/jdk17/temurin-jammy/Dockerfile
+++ b/10.1/jdk17/temurin-jammy/Dockerfile
@@ -145,4 +145,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/10.1/jre11/temurin-jammy/Dockerfile
+++ b/10.1/jre11/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/10.1/jre17/temurin-jammy/Dockerfile
+++ b/10.1/jre17/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk11/temurin-focal/Dockerfile
+++ b/8.5/jdk11/temurin-focal/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk11/temurin-jammy/Dockerfile
+++ b/8.5/jdk11/temurin-jammy/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk17/temurin-focal/Dockerfile
+++ b/8.5/jdk17/temurin-focal/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk17/temurin-jammy/Dockerfile
+++ b/8.5/jdk17/temurin-jammy/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk8/temurin-focal/Dockerfile
+++ b/8.5/jdk8/temurin-focal/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk8/temurin-jammy/Dockerfile
+++ b/8.5/jdk8/temurin-jammy/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jre11/temurin-focal/Dockerfile
+++ b/8.5/jre11/temurin-focal/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jre11/temurin-jammy/Dockerfile
+++ b/8.5/jre11/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jre17/temurin-focal/Dockerfile
+++ b/8.5/jre17/temurin-focal/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jre17/temurin-jammy/Dockerfile
+++ b/8.5/jre17/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jre8/temurin-focal/Dockerfile
+++ b/8.5/jre8/temurin-focal/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/8.5/jre8/temurin-jammy/Dockerfile
+++ b/8.5/jre8/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk11/temurin-focal/Dockerfile
+++ b/9.0/jdk11/temurin-focal/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk11/temurin-jammy/Dockerfile
+++ b/9.0/jdk11/temurin-jammy/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk17/temurin-focal/Dockerfile
+++ b/9.0/jdk17/temurin-focal/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk17/temurin-jammy/Dockerfile
+++ b/9.0/jdk17/temurin-jammy/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk8/temurin-focal/Dockerfile
+++ b/9.0/jdk8/temurin-focal/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk8/temurin-jammy/Dockerfile
+++ b/9.0/jdk8/temurin-jammy/Dockerfile
@@ -146,4 +146,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jre11/temurin-focal/Dockerfile
+++ b/9.0/jre11/temurin-focal/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jre11/temurin-jammy/Dockerfile
+++ b/9.0/jre11/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jre17/temurin-focal/Dockerfile
+++ b/9.0/jre17/temurin-focal/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jre17/temurin-jammy/Dockerfile
+++ b/9.0/jre17/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jre8/temurin-focal/Dockerfile
+++ b/9.0/jre8/temurin-focal/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/9.0/jre8/temurin-jammy/Dockerfile
+++ b/9.0/jre8/temurin-jammy/Dockerfile
@@ -40,4 +40,8 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
 CMD ["catalina.sh", "run"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -277,4 +277,10 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
+{{ if vendor_variant | contains("temurin") then ( -}}
+
+# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
+ENTRYPOINT []
+
+{{ ) else "" end -}}
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
The upstream entrypoint is `sh` and so loses dotted environment variables, lets prevent that from happening by just skipping it as the `tomcat` images are not reliant on its functionality. See https://github.com/docker-library/docs/pull/2338 and https://github.com/adoptium/containers/pull/392 for info about what it provides.

Fixes https://github.com/docker-library/tomcat/issues/302 which is a recurrence of https://github.com/docker-library/tomcat/issues/77