### PR TITLE
Add `corretto-al2023` variants

### DIFF
--- a/10.1/jdk11/corretto-al2023/Dockerfile
+++ b/10.1/jdk11/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:11-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-10/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 5C3C5F3E314C866292F359A8F3AD5C94A67F707E A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 10
+ENV TOMCAT_VERSION 10.1.13
+ENV TOMCAT_SHA512 406c0c367ac6ad95bb724ecc3a3c340ad7ded8c62287d657811eeec496eaaca1f5add52d2f46111da1426ae67090c543f6deccfeb5fdf4bdae32f9b39e773265
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,25 +89,22 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \
@@ -110,22 +117,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +152,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/10.1/jdk11/temurin-jammy/Dockerfile
+++ b/10.1/jdk11/temurin-jammy/Dockerfile
@@ -105,6 +105,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -121,10 +125,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/10.1/jdk17/corretto-al2023/Dockerfile
+++ b/10.1/jdk17/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:17-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-10/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 5C3C5F3E314C866292F359A8F3AD5C94A67F707E A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 10
+ENV TOMCAT_VERSION 10.1.13
+ENV TOMCAT_SHA512 406c0c367ac6ad95bb724ecc3a3c340ad7ded8c62287d657811eeec496eaaca1f5add52d2f46111da1426ae67090c543f6deccfeb5fdf4bdae32f9b39e773265
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,25 +89,22 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \
@@ -110,22 +117,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +152,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/10.1/jdk17/temurin-jammy/Dockerfile
+++ b/10.1/jdk17/temurin-jammy/Dockerfile
@@ -105,6 +105,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -121,10 +125,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/10.1/jdk21/corretto-al2023/Dockerfile
+++ b/10.1/jdk21/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:21-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-10/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 5C3C5F3E314C866292F359A8F3AD5C94A67F707E A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 10
+ENV TOMCAT_VERSION 10.1.13
+ENV TOMCAT_SHA512 406c0c367ac6ad95bb724ecc3a3c340ad7ded8c62287d657811eeec496eaaca1f5add52d2f46111da1426ae67090c543f6deccfeb5fdf4bdae32f9b39e773265
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,25 +89,22 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \
@@ -110,22 +117,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +152,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/11.0/jdk21/corretto-al2023/Dockerfile
+++ b/11.0/jdk21/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:21-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-11/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 11
+ENV TOMCAT_VERSION 11.0.0-M11
+ENV TOMCAT_SHA512 0404346b353030f776448af8ae4495d45c4c73c27bf9a9bfa5c53508ec51b0200e93e21f5526a28856639127fc20cc546e880908ef182b1653e5fd5ddb056fc5
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,25 +89,22 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
 			--with-java-home="$JAVA_HOME" \
-			--with-ssl \
 		; \
 		nproc="$(nproc)"; \
 		make -j "$nproc"; \
@@ -110,22 +117,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +152,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk11/corretto-al2/Dockerfile
+++ b/8.5/jdk11/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk11/corretto-al2023/Dockerfile
+++ b/8.5/jdk11/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:11-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -25,13 +25,24 @@ ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be65254
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk11/temurin-focal/Dockerfile
+++ b/8.5/jdk11/temurin-focal/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk11/temurin-jammy/Dockerfile
+++ b/8.5/jdk11/temurin-jammy/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk17/corretto-al2/Dockerfile
+++ b/8.5/jdk17/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk17/corretto-al2023/Dockerfile
+++ b/8.5/jdk17/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:17-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -25,13 +25,24 @@ ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be65254
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk17/temurin-jammy/Dockerfile
+++ b/8.5/jdk17/temurin-jammy/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk21/corretto-al2/Dockerfile
+++ b/8.5/jdk21/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk21/corretto-al2023/Dockerfile
+++ b/8.5/jdk21/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:21-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -25,13 +25,24 @@ ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be65254
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk8/corretto-al2/Dockerfile
+++ b/8.5/jdk8/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk8/corretto-al2023/Dockerfile
+++ b/8.5/jdk8/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:8-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -25,13 +25,24 @@ ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be65254
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/8.5/jdk8/temurin-focal/Dockerfile
+++ b/8.5/jdk8/temurin-focal/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jdk8/temurin-jammy/Dockerfile
+++ b/8.5/jdk8/temurin-jammy/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/8.5/jre8/corretto-al2023/Dockerfile
+++ b/8.5/jre8/corretto-al2023/Dockerfile
@@ -1,0 +1,43 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM amazoncorretto:8-al2023-jre
+
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+RUN mkdir -p "$CATALINA_HOME"
+WORKDIR $CATALINA_HOME
+
+# let "Tomcat Native" live somewhere isolated
+ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
+
+# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
+ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+
+ENV TOMCAT_MAJOR 8
+ENV TOMCAT_VERSION 8.5.93
+ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+
+COPY --from=tomcat:8.5.93-jdk8-corretto-al2023 $CATALINA_HOME $CATALINA_HOME
+RUN set -eux; \
+	xargs -rt dnf install -y < "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt"; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf
+
+# verify Tomcat Native is working properly
+RUN set -eux; \
+	nativeLines="$(catalina.sh configtest 2>&1)"; \
+	nativeLines="$(echo "$nativeLines" | grep 'Apache Tomcat Native')"; \
+	nativeLines="$(echo "$nativeLines" | sort -u)"; \
+	if ! echo "$nativeLines" | grep -E 'INFO: Loaded( APR based)? Apache Tomcat Native library' >&2; then \
+		echo >&2 "$nativeLines"; \
+		exit 1; \
+	fi
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/9.0/jdk11/corretto-al2/Dockerfile
+++ b/9.0/jdk11/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk11/corretto-al2023/Dockerfile
+++ b/9.0/jdk11/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:11-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-9/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 9
+ENV TOMCAT_VERSION 9.0.80
+ENV TOMCAT_SHA512 24014441b0ccdd2dda238efa56e1a039476488943e6cf04f8a372a340a49dd21ce174ed68e2f5fcc43401e85fae6d00c5eac3d357653e91601737b6fa94476de
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk11/temurin-focal/Dockerfile
+++ b/9.0/jdk11/temurin-focal/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk11/temurin-jammy/Dockerfile
+++ b/9.0/jdk11/temurin-jammy/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk17/corretto-al2/Dockerfile
+++ b/9.0/jdk17/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk17/corretto-al2023/Dockerfile
+++ b/9.0/jdk17/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:17-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-9/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 9
+ENV TOMCAT_VERSION 9.0.80
+ENV TOMCAT_SHA512 24014441b0ccdd2dda238efa56e1a039476488943e6cf04f8a372a340a49dd21ce174ed68e2f5fcc43401e85fae6d00c5eac3d357653e91601737b6fa94476de
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk17/temurin-focal/Dockerfile
+++ b/9.0/jdk17/temurin-focal/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk17/temurin-jammy/Dockerfile
+++ b/9.0/jdk17/temurin-jammy/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk21/corretto-al2/Dockerfile
+++ b/9.0/jdk21/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk21/corretto-al2023/Dockerfile
+++ b/9.0/jdk21/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:21-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-9/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 9
+ENV TOMCAT_VERSION 9.0.80
+ENV TOMCAT_SHA512 24014441b0ccdd2dda238efa56e1a039476488943e6cf04f8a372a340a49dd21ce174ed68e2f5fcc43401e85fae6d00c5eac3d357653e91601737b6fa94476de
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk8/corretto-al2/Dockerfile
+++ b/9.0/jdk8/corretto-al2/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -44,7 +44,8 @@ RUN set -eux; \
 			yumdb set reason dep $todo; \
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -91,8 +92,9 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
 		openssl11-devel \
@@ -115,6 +117,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
 		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
@@ -130,10 +136,6 @@ RUN set -eux; \
 	yum autoremove -y; \
 	yum clean all; \
 	rm -rf /var/cache/yum; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk8/corretto-al2023/Dockerfile
+++ b/9.0/jdk8/corretto-al2023/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jdk-focal
+FROM amazoncorretto:8-al2023-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -15,23 +15,34 @@ WORKDIR $CATALINA_HOME
 ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 
-# see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
+# see https://www.apache.org/dist/tomcat/tomcat-9/KEYS
 # see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
-ENV GPG_KEYS 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 5C3C5F3E314C866292F359A8F3AD5C94A67F707E 765908099ACF92702C7D949BFA0C35EA8AA299F1 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+ENV GPG_KEYS 48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
 
-ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.93
-ENV TOMCAT_SHA512 fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc
+ENV TOMCAT_MAJOR 9
+ENV TOMCAT_VERSION 9.0.80
+ENV TOMCAT_SHA512 24014441b0ccdd2dda238efa56e1a039476488943e6cf04f8a372a340a49dd21ce174ed68e2f5fcc43401e85fae6d00c5eac3d357653e91601737b6fa94476de
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		gnupg \
-	; \
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
+		local pkg todo=''; \
+		for pkg; do \
+			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
+				todo="$todo $pkg"; \
+			fi; \
+		done; \
+		if [ -n "$todo" ]; then \
+			set -x; \
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+		fi; \
+	) }; \
+	_install_temporary gzip tar; \
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+
 	\
 	ddist() { \
 		local f="$1"; shift; \
@@ -69,7 +80,6 @@ RUN set -eux; \
 	tar -xf tomcat.tar.gz --strip-components=1; \
 	rm bin/*.bat; \
 	rm tomcat.tar.gz*; \
-	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"; \
 	\
 # https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
@@ -79,20 +89,18 @@ RUN set -eux; \
 	\
 	nativeBuildDir="$(mktemp -d)"; \
 	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
-	apt-get install -y --no-install-recommends \
-		dpkg-dev \
+	_install_temporary \
+		apr-devel \
+		findutils \
 		gcc \
-		libapr1-dev \
-		libssl-dev \
 		make \
+		openssl-devel \
 	; \
 	( \
 		export CATALINA_HOME="$PWD"; \
 		cd "$nativeBuildDir/native"; \
-		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 		aprConfig="$(command -v apr-1-config)"; \
 		./configure \
-			--build="$gnuArch" \
 			--libdir="$TOMCAT_NATIVE_LIBDIR" \
 			--prefix="$CATALINA_HOME" \
 			--with-apr="$aprConfig" \
@@ -110,22 +118,21 @@ RUN set -eux; \
 # https://github.com/docker-library/tomcat/issues/77
 	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+# mark any explicit dependencies as manually installed
 	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ && $(NF-1) != "=>" { print $(NF-1) }' \
 		| xargs -rt readlink -e \
 		| sort -u \
-		| xargs -rt dpkg-query --search \
-		| cut -d: -f1 \
+		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r apt-mark manual \
+		| xargs -r dnf mark install \
 	; \
 	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*; \
+# clean up anything added temporarily and not later marked as necessary
+	dnf autoremove -y; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -146,8 +153,4 @@ RUN set -eux; \
 	fi
 
 EXPOSE 8080
-
-# upstream eclipse-temurin-provided entrypoint script caused https://github.com/docker-library/tomcat/issues/77 to come back as https://github.com/docker-library/tomcat/issues/302; use "/entrypoint.sh" at your own risk
-ENTRYPOINT []
-
 CMD ["catalina.sh", "run"]

--- a/9.0/jdk8/temurin-focal/Dockerfile
+++ b/9.0/jdk8/temurin-focal/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jdk8/temurin-jammy/Dockerfile
+++ b/9.0/jdk8/temurin-jammy/Dockerfile
@@ -106,6 +106,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
@@ -122,10 +126,6 @@ RUN set -eux; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35

--- a/9.0/jre8/corretto-al2023/Dockerfile
+++ b/9.0/jre8/corretto-al2023/Dockerfile
@@ -1,0 +1,43 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM amazoncorretto:8-al2023-jre
+
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+RUN mkdir -p "$CATALINA_HOME"
+WORKDIR $CATALINA_HOME
+
+# let "Tomcat Native" live somewhere isolated
+ENV TOMCAT_NATIVE_LIBDIR $CATALINA_HOME/native-jni-lib
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
+
+# see https://www.apache.org/dist/tomcat/tomcat-9/KEYS
+# see also "versions.sh" (https://github.com/docker-library/tomcat/blob/master/versions.sh)
+ENV GPG_KEYS 48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+
+ENV TOMCAT_MAJOR 9
+ENV TOMCAT_VERSION 9.0.80
+ENV TOMCAT_SHA512 24014441b0ccdd2dda238efa56e1a039476488943e6cf04f8a372a340a49dd21ce174ed68e2f5fcc43401e85fae6d00c5eac3d357653e91601737b6fa94476de
+
+COPY --from=tomcat:9.0.80-jdk8-corretto-al2023 $CATALINA_HOME $CATALINA_HOME
+RUN set -eux; \
+	xargs -rt dnf install -y < "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt"; \
+	dnf clean all; \
+	rm -rf /var/cache/dnf
+
+# verify Tomcat Native is working properly
+RUN set -eux; \
+	nativeLines="$(catalina.sh configtest 2>&1)"; \
+	nativeLines="$(echo "$nativeLines" | grep 'Apache Tomcat Native')"; \
+	nativeLines="$(echo "$nativeLines" | sort -u)"; \
+	if ! echo "$nativeLines" | grep -E 'INFO: Loaded( APR based)? Apache Tomcat Native library' >&2; then \
+		echo >&2 "$nativeLines"; \
+		exit 1; \
+	fi
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -94,13 +94,15 @@ RUN set -eux; \
 		gnupg \
 	; \
 {{ ) else ( -}}
+{{ if is_yum then ( -}}
 # http://yum.baseurl.org/wiki/YumDB.html
 	if ! command -v yumdb > /dev/null; then \
 		yum install -y --setopt=skip_missing_names_on_install=False yum-utils; \
 		yumdb set reason dep yum-utils; \
 	fi; \
-# a helper function to "yum install" things, but only if they aren't installed (and to set their "reason" to "dep" so "yum autoremove" can purge them for us)
-	_yum_install_temporary() { ( set -eu +x; \
+{{ ) else "" end -}}
+# a helper function to install things, but only if they aren't installed (and to set their "reason" to "dep" so "autoremove" can purge them for us)
+	_install_temporary() { ( set -eu +x; \
 		local pkg todo=''; \
 		for pkg; do \
 			if ! rpm --query "$pkg" > /dev/null 2>&1; then \
@@ -109,11 +111,21 @@ RUN set -eux; \
 		done; \
 		if [ -n "$todo" ]; then \
 			set -x; \
+{{ if is_yum then ( -}}
 			yum install -y --setopt=skip_missing_names_on_install=False $todo; \
 			yumdb set reason dep $todo; \
+{{ ) else ( -}}
+			dnf install -y $todo; \
+			dnf mark remove $todo; \
+{{ ) end -}}
 		fi; \
 	) }; \
-	_yum_install_temporary gzip tar; \
+	_install_temporary gzip tar; \
+{{ if vendor_variant | contains("al20") then ( -}}
+# gnupg2-minimal (installed by default) conflicts with gnupg2 and does not include dirmngr so cannot fetch keys
+	dnf install -y --allowerasing gnupg2; \
+{{ ) else "" end -}}
+
 {{ ) end -}}
 	\
 	ddist() { \
@@ -173,11 +185,16 @@ RUN set -eux; \
 		make \
 	; \
 {{ ) else ( -}}
-	_yum_install_temporary \
+	_install_temporary \
 		apr-devel \
+		findutils \
 		gcc \
 		make \
+{{ if vendor_variant | variant_is_al2 then ( -}}
 		openssl11-devel \
+{{ ) else ( -}}
+		openssl-devel \
+{{ ) end -}}
 	; \
 {{ ) end -}}
 	( \
@@ -206,6 +223,10 @@ RUN set -eux; \
 	rm -rf "$nativeBuildDir"; \
 	rm bin/tomcat-native.tar.gz; \
 	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
 {{ if is_apt then ( -}}
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
@@ -232,18 +253,14 @@ RUN set -eux; \
 		| xargs -rt rpm --query --whatprovides \
 		| sort -u \
 		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
-		| xargs -r yumdb set reason user \
+		| xargs -r {{ if is_yum then "yumdb set reason user" else "dnf mark install" end }} \
 	; \
 	\
 # clean up anything added temporarily and not later marked as necessary
-	yum autoremove -y; \
-	yum clean all; \
-	rm -rf /var/cache/yum; \
+	{{ if is_yum then "yum" else "dnf" end }} autoremove -y; \
+	{{ if is_yum then "yum" else "dnf" end }} clean all; \
+	rm -rf /var/cache/{{ if is_yum then "yum" else "dnf" end }}; \
 {{ ) end -}}
-	\
-# sh removes env vars it doesn't support (ones with periods)
-# https://github.com/docker-library/tomcat/issues/77
-	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
 	\
 # fix permissions (especially for running as non-root)
 # https://github.com/docker-library/tomcat/issues/35
@@ -260,9 +277,9 @@ RUN set -eux; \
 	xargs -rt apt-get install -y --no-install-recommends < "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt"; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) else ( -}}
-	xargs -rt yum install -y --setopt=skip_missing_names_on_install=False < "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt"; \
-	yum clean all; \
-	rm -rf /var/cache/yum
+	xargs -rt {{ if is_yum then "yum" else "dnf" end }} install -y{{ if is_yum then " --setopt=skip_missing_names_on_install=False" else "" end }} < "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt"; \
+	{{ if is_yum then "yum" else "dnf" end }} clean all; \
+	rm -rf /var/cache/{{ if is_yum then "yum" else "dnf" end }}
 {{ ) end -}}
 {{ ) end -}}
 

--- a/shared.jq
+++ b/shared.jq
@@ -18,6 +18,14 @@ def is_supported_java_version(java):
 		java >= 7
 	end
 ;
+def variant_is_al2: # NOT al20XX
+	contains("al2") and (contains("al20") | not)
+;
+def is_yum:
+	vendor_variant | (
+		variant_is_al2
+	)
+;
 def is_apt:
 	vendor_variant | (
 		contains("al2")
@@ -33,7 +41,7 @@ def has_openssl_ge_3(variant):
 	# https://github.com/apache/tomcat-native/commit/f7930fa16f095717cfc641a8d24e60c343765adc
 	variant | (
 		# amazonlinux
-		contains("al2") # corretto
+		variant_is_al2 # corretto
 		# debian
 		or contains("bullseye") # openjdk
 		or contains("buster") # openjdk

--- a/versions.json
+++ b/versions.json
@@ -2,36 +2,46 @@
   "10.1": {
     "sha512": "406c0c367ac6ad95bb724ecc3a3c340ad7ded8c62287d657811eeec496eaaca1f5add52d2f46111da1426ae67090c543f6deccfeb5fdf4bdae32f9b39e773265",
     "variants": [
+      "jdk21/corretto-al2023",
       "jdk17/temurin-jammy",
       "jre17/temurin-jammy",
+      "jdk17/corretto-al2023",
       "jdk11/temurin-jammy",
-      "jre11/temurin-jammy"
+      "jre11/temurin-jammy",
+      "jdk11/corretto-al2023"
     ],
     "version": "10.1.13"
   },
   "11.0": {
     "sha512": "0404346b353030f776448af8ae4495d45c4c73c27bf9a9bfa5c53508ec51b0200e93e21f5526a28856639127fc20cc546e880908ef182b1653e5fd5ddb056fc5",
-    "variants": [],
+    "variants": [
+      "jdk21/corretto-al2023"
+    ],
     "version": "11.0.0-M11"
   },
   "8.5": {
     "sha512": "fdd9bd768c2c8b7f57c75f1a4863bd2bde55e8ea7c8b9cb81427ea8be652540bdcb1ff1cd625b9fb0dd48eb750ebef0f0244d12ac574998d5df3a0d339699bcc",
     "variants": [
+      "jdk21/corretto-al2023",
       "jdk21/corretto-al2",
       "jdk17/temurin-jammy",
       "jre17/temurin-jammy",
       "jdk17/temurin-focal",
       "jre17/temurin-focal",
+      "jdk17/corretto-al2023",
       "jdk17/corretto-al2",
       "jdk11/temurin-jammy",
       "jre11/temurin-jammy",
       "jdk11/temurin-focal",
       "jre11/temurin-focal",
+      "jdk11/corretto-al2023",
       "jdk11/corretto-al2",
       "jdk8/temurin-jammy",
       "jre8/temurin-jammy",
       "jdk8/temurin-focal",
       "jre8/temurin-focal",
+      "jdk8/corretto-al2023",
+      "jre8/corretto-al2023",
       "jdk8/corretto-al2"
     ],
     "version": "8.5.93"
@@ -39,21 +49,26 @@
   "9.0": {
     "sha512": "24014441b0ccdd2dda238efa56e1a039476488943e6cf04f8a372a340a49dd21ce174ed68e2f5fcc43401e85fae6d00c5eac3d357653e91601737b6fa94476de",
     "variants": [
+      "jdk21/corretto-al2023",
       "jdk21/corretto-al2",
       "jdk17/temurin-jammy",
       "jre17/temurin-jammy",
       "jdk17/temurin-focal",
       "jre17/temurin-focal",
+      "jdk17/corretto-al2023",
       "jdk17/corretto-al2",
       "jdk11/temurin-jammy",
       "jre11/temurin-jammy",
       "jdk11/temurin-focal",
       "jre11/temurin-focal",
+      "jdk11/corretto-al2023",
       "jdk11/corretto-al2",
       "jdk8/temurin-jammy",
       "jre8/temurin-jammy",
       "jdk8/temurin-focal",
       "jre8/temurin-focal",
+      "jdk8/corretto-al2023",
+      "jre8/corretto-al2023",
       "jdk8/corretto-al2"
     ],
     "version": "9.0.80"

--- a/versions.sh
+++ b/versions.sh
@@ -31,7 +31,7 @@ for javaVersion in 21 17 11 8; do
 	for vendorVariant in \
 		temurin-{jammy,focal} \
 		openjdk{,-slim}-{bookworm,bullseye,buster} \
-		corretto-al2 \
+		corretto-al2023 corretto-al2 \
 	; do
 		for javaVariant in {jdk,jre}"$javaVersion"; do
 			export variant="$javaVariant/$vendorVariant"


### PR DESCRIPTION
Adding these to get a JDK that is version 21+ with OpenSSL 3.x available. This is mostly because OpenJDK 21 reached GA and so it was dropped from the `openjdk` images (https://github.com/docker-library/openjdk/pull/531) and as such, we now don't have a base image for the Tomcat 11 alpha builds (https://github.com/docker-library/tomcat/commit/836a85001e27a35146ce57cc1b68a0747e6fa462).

Alternative is to wait for the eclipse-temurin JDK 21 images: https://github.com/adoptium/temurin/issues/7, https://adoptium.net/blog/2023/09/temurin21-delay/.

This is subset of https://github.com/docker-library/tomcat/pull/299; perhaps it should be limited in some way?

---

Edit: 😢That's a lot of extra code because al2023 is not a drop in replacement for al2: https://github.com/docker-library/tomcat/pull/305/commits/a40c1c364a714ac77f442d5e473ab2d4ce705f8a