### PR TITLE
Remove unsupported/EOL distros from templating

### DIFF
--- a/shared.jq
+++ b/shared.jq
@@ -32,10 +32,5 @@ def has_openssl_ge_3(variant):
 	variant | (
 		# amazonlinux
 		contains("al2") # corretto
-		# debian
-		or contains("bullseye") # openjdk
-		or contains("buster") # openjdk
-		# ubuntu
-		or contains("focal") # temurin
 	) | not
 ;

--- a/versions.sh
+++ b/versions.sh
@@ -30,7 +30,7 @@ for javaVersion in 21 17 11 8; do
 	# Eclipse Temurin, followed by OpenJDK, and then all other variants alphabetically
 	for vendorVariant in \
 		temurin-{noble,jammy} \
-		openjdk{,-slim}-{bookworm,bullseye,buster} \
+		openjdk{,-slim}-{trixie,bookworm} \
 		corretto-al2 \
 	; do
 		for javaVariant in {jdk,jre}"$javaVersion"; do


### PR DESCRIPTION
Noticed this while updating https://github.com/docker-library/tomcat/pull/299 (which shows that none of these versions even exist anywhere in the _potential_ matrix, so we're OK to remove all references to them).